### PR TITLE
Add configurable hook assist prediction

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -706,6 +706,8 @@ MACRO_CONFIG_INT(ClShowHookCollOwn, cl_show_hook_coll_own, 1, 0, 2, CFGFLAG_CLIE
 MACRO_CONFIG_INT(ClHookCollSize, cl_hook_coll_size, 0, 0, 20, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Width of your own hook collision line")
 MACRO_CONFIG_INT(ClHookCollSizeOther, cl_hook_coll_size_other, 0, 0, 20, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Width of others' hook collision line")
 MACRO_CONFIG_INT(ClHookCollAlpha, cl_hook_coll_alpha, 100, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Alpha of hook collision line (0 invisible, 100 fully visible)")
+MACRO_CONFIG_INT(ClHookAssist, cl_hook_assist, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Automatically release the hook when a predicted freeze or teleport is detected")
+MACRO_CONFIG_INT(ClHookAssistCheck, cl_hook_assist_check, 300, 0, 5000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Prediction window for hook assist in milliseconds")
 
 MACRO_CONFIG_COL(ClHookCollColorNoColl, cl_hook_coll_color_no_coll, 65407, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Specifies the color of a hookline that hits nothing.")
 MACRO_CONFIG_COL(ClHookCollColorHookableColl, cl_hook_coll_color_hookable_coll, 6401973, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Specifies the color of a hookline that hits hookable tiles.")

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -10,6 +10,7 @@
 #include <game/client/components/menus.h>
 #include <game/client/components/scoreboard.h>
 #include <game/client/gameclient.h>
+#include <game/client/prediction/entities/character.h>
 #include <game/collision.h>
 
 #include <base/vmath.h>
@@ -259,12 +260,14 @@ int CControls::SnapInput(int *pData)
 		m_aInputData[g_Config.m_ClDummy].m_Direction = 0;
 		if(m_aInputDirectionLeft[g_Config.m_ClDummy] && !m_aInputDirectionRight[g_Config.m_ClDummy])
 			m_aInputData[g_Config.m_ClDummy].m_Direction = -1;
-		if(!m_aInputDirectionLeft[g_Config.m_ClDummy] && m_aInputDirectionRight[g_Config.m_ClDummy])
-			m_aInputData[g_Config.m_ClDummy].m_Direction = 1;
+                if(!m_aInputDirectionLeft[g_Config.m_ClDummy] && m_aInputDirectionRight[g_Config.m_ClDummy])
+                        m_aInputData[g_Config.m_ClDummy].m_Direction = 1;
 
-		// dummy copy moves
-		if(g_Config.m_ClDummyCopyMoves)
-		{
+                HookAssist();
+
+                // dummy copy moves
+                if(g_Config.m_ClDummyCopyMoves)
+                {
 			CNetObj_PlayerInput *pDummyInput = &GameClient()->m_DummyInput;
 			pDummyInput->m_Direction = m_aInputData[g_Config.m_ClDummy].m_Direction;
 			pDummyInput->m_Hook = m_aInputData[g_Config.m_ClDummy].m_Hook;
@@ -337,8 +340,8 @@ int CControls::SnapInput(int *pData)
 
 void CControls::OnRender()
 {
-	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
-		return;
+        if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+                return;
 
 	if(g_Config.m_ClAutoswitchWeaponsOutOfAmmo && !GameClient()->m_GameInfo.m_UnlimitedAmmo && GameClient()->m_Snap.m_pLocalCharacter)
 	{
@@ -377,14 +380,106 @@ void CControls::OnRender()
 	}
 	else
 	{
-		m_aTargetPos[g_Config.m_ClDummy] = m_aMousePos[g_Config.m_ClDummy];
-	}
+                m_aTargetPos[g_Config.m_ClDummy] = m_aMousePos[g_Config.m_ClDummy];
+        }
+}
+
+void CControls::HookAssist()
+{
+        if(!g_Config.m_ClHookAssist)
+                return;
+
+        const int Dummy = g_Config.m_ClDummy;
+        const int LocalId = GameClient()->m_aLocalIds[Dummy];
+        if(LocalId < 0)
+                return;
+
+        CNetObj_PlayerInput &Input = m_aInputData[Dummy];
+        if(Input.m_Hook <= 0)
+                return;
+
+        const int PredictionTicks = HookAssistPredictionTicks();
+        if(PredictionTicks <= 0)
+                return;
+
+        if(PredictHookDanger(Input, LocalId, PredictionTicks))
+                Input.m_Hook = 0;
+}
+
+int CControls::HookAssistPredictionTicks() const
+{
+        if(!g_Config.m_ClHookAssist)
+                return 0;
+
+        const int DurationMs = maximum(0, g_Config.m_ClHookAssistCheck);
+        if(DurationMs <= 0)
+                return 0;
+
+        const int TickSpeed = Client()->GameTickSpeed();
+        const int Ticks = (DurationMs * TickSpeed + 999) / 1000;
+        return maximum(1, Ticks);
+}
+
+bool CControls::PredictHookDanger(const CNetObj_PlayerInput &Input, int LocalClientId, int PredictionTicks)
+{
+        if(PredictionTicks <= 0)
+                return false;
+
+        if(!GameClient()->Predict())
+                return false;
+
+        CGameWorld &ExtraWorld = GameClient()->m_ExtraPredictedWorld;
+        ExtraWorld.CopyWorldClean(&GameClient()->m_PredictedWorld);
+
+        CCharacter *pChar = ExtraWorld.GetCharacterById(LocalClientId);
+        if(!pChar)
+                return false;
+
+        if(HookAssistDetectDanger(pChar))
+                return true;
+
+        CNetObj_PlayerInput SimulatedInput = Input;
+        SimulatedInput.m_PlayerFlags |= PLAYERFLAG_PLAYING;
+
+        for(int i = 0; i < PredictionTicks; ++i)
+        {
+                pChar->OnDirectInput(&SimulatedInput);
+                pChar->OnPredictedInput(&SimulatedInput);
+
+                ExtraWorld.m_GameTick++;
+                ExtraWorld.Tick();
+
+                pChar = ExtraWorld.GetCharacterById(LocalClientId);
+                if(!pChar)
+                        return false;
+
+                if(HookAssistDetectDanger(pChar))
+                        return true;
+        }
+
+        return false;
+}
+
+bool CControls::HookAssistDetectDanger(const CCharacter *pChar) const
+{
+        if(!pChar)
+                return false;
+
+        if(pChar->m_FreezeTime > 0)
+                return true;
+
+        const vec2 Pos = pChar->m_Pos;
+        const int MapIndex = Collision()->GetPureMapIndex(Pos.x, Pos.y);
+        if(MapIndex < 0)
+                return false;
+
+        return Collision()->IsTeleport(MapIndex) || Collision()->IsCheckTeleport(MapIndex) || Collision()->IsCheckEvilTeleport(MapIndex) || Collision()->IsEvilTeleport(MapIndex);
 }
 
 bool CControls::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
 {
-	if(GameClient()->m_Snap.m_pGameInfoObj && (GameClient()->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_PAUSED))
-		return false;
+        if(GameClient()->m_Snap.m_pGameInfoObj && (GameClient()->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_PAUSED))
+                return false;
 
 	if(CursorType == IInput::CURSOR_JOYSTICK && g_Config.m_InpControllerAbsolute && GameClient()->m_Snap.m_pGameInfoObj && !GameClient()->m_Snap.m_SpecInfo.m_Active)
 	{

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -11,6 +11,8 @@
 #include <game/client/component.h>
 #include <generated/protocol.h>
 
+class CCharacter;
+
 class CControls : public CComponent
 {
 public:
@@ -48,9 +50,14 @@ public:
 	bool CheckNewInput();
 
 private:
-	static void ConKeyInputState(IConsole::IResult *pResult, void *pUserData);
-	static void ConKeyInputCounter(IConsole::IResult *pResult, void *pUserData);
-	static void ConKeyInputSet(IConsole::IResult *pResult, void *pUserData);
-	static void ConKeyInputNextPrevWeapon(IConsole::IResult *pResult, void *pUserData);
+        static void ConKeyInputState(IConsole::IResult *pResult, void *pUserData);
+        static void ConKeyInputCounter(IConsole::IResult *pResult, void *pUserData);
+        static void ConKeyInputSet(IConsole::IResult *pResult, void *pUserData);
+        static void ConKeyInputNextPrevWeapon(IConsole::IResult *pResult, void *pUserData);
+
+        void HookAssist();
+        int HookAssistPredictionTicks() const;
+        bool PredictHookDanger(const CNetObj_PlayerInput &Input, int LocalClientId, int PredictionTicks);
+        bool HookAssistDetectDanger(const CCharacter *pChar) const;
 };
 #endif

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -492,16 +492,25 @@ void CMenus::RenderSettingsTClientSettngs(CUIRect MainView)
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcFastInput, TCLocalize("Fast Inputs (-20ms visual delay)"), &g_Config.m_TcFastInput, &Column, LineSize);
 
 	Column.HSplitTop(MarginSmall, nullptr, &Column);
-	if(g_Config.m_TcFastInput)
-		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcFastInputOthers, TCLocalize("Extra tick other tees (increases other tees latency, \nmakes dragging slightly easier when using fast input)"), &g_Config.m_TcFastInputOthers, &Column, LineSize);
-	else
-		Column.HSplitTop(LineSize, nullptr, &Column);
-	// A little extra spacing because these are multi line
-	Column.HSplitTop(MarginSmall, nullptr, &Column);
+        if(g_Config.m_TcFastInput)
+                DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_TcFastInputOthers, TCLocalize("Extra tick other tees (increases other tees latency, \nmakes dragging slightly easier when using fast input)"), &g_Config.m_TcFastInputOthers, &Column, LineSize);
+        else
+                Column.HSplitTop(LineSize, nullptr, &Column);
+        // A little extra spacing because these are multi line
+        Column.HSplitTop(MarginSmall, nullptr, &Column);
 
-	s_SectionBoxes.back().h = Column.y - s_SectionBoxes.back().y;
+        DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClHookAssist, TCLocalize("Enable hook assist"), &g_Config.m_ClHookAssist, &Column, LineSize);
+        if(g_Config.m_ClHookAssist)
+        {
+                Column.HSplitTop(LineSize, &Button, &Column);
+                Ui()->DoScrollbarOption(&g_Config.m_ClHookAssistCheck, &g_Config.m_ClHookAssistCheck, &Button, TCLocalize("Hook assist prediction"), 0, 5000, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_NOCLAMPVALUE, "ms");
+        }
+        else
+                Column.HSplitTop(LineSize, nullptr, &Column);
 
-	// ***** Anti Latency Tools ***** //
+        s_SectionBoxes.back().h = Column.y - s_SectionBoxes.back().y;
+
+        // ***** Anti Latency Tools ***** //
 	Column.HSplitTop(MarginBetweenSections, nullptr, &Column);
 	s_SectionBoxes.push_back(Column);
 	Column.HSplitTop(HeadlineHeight, &Label, &Column);


### PR DESCRIPTION
## Summary
- add hook assist logic that predicts freezes/teleports and automatically releases the hook before danger
- add configuration variables and settings UI to toggle hook assist and tune the prediction window

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da33f4ea70832c9e37d9fae98f5080